### PR TITLE
fix: ONCEHUB-100613 update version from 5.1.3-beta.2 to 5.1.3 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/knowledgeowl-angular",
-  "version": "5.1.3-beta.2",
+  "version": "5.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/knowledgeowl-angular",
-      "version": "5.1.3-beta.2",
+      "version": "5.1.3",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/scheduleonce/knowledgeowl-angular.git"
   },
   "license": "MIT",
-  "version": "5.1.3-beta.2",
+  "version": "5.1.3",
   "scripts": {
     "ng": "ng",
     "build": "ng build --configuration production && cp README.md dist/knowledgeowl-angular",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oncehub/knowledgeowl-angular",
-    "version": "5.1.3-beta.2",
+    "version": "5.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oncehub/knowledgeowl-angular",
-            "version": "5.1.3-beta.2",
+            "version": "5.1.3",
             "license": "MIT"
         }
     }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oncehub/knowledgeowl-angular",
-    "version": "5.1.3-beta.2",
+    "version": "5.1.3",
     "description": "Knowledge Owl Angular",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
fix: [ONCEHUB-100613](https://scheduleonce.atlassian.net/browse/ONCEHUB-100613) update version from 5.1.3-beta.2 to 5.1.3 in package.json and package-lock.json

This pull request updates the package version from `5.1.3-beta.2` to `5.1.3` across the project files to prepare for a stable release. No other functional or code changes are included.

Version update:

* Updated the version number in `package.json` to `5.1.3`.
* Updated the version number in `src/package.json` to `5.1.3`.
* Updated the version number in `src/package-lock.json` to `5.1.3`.

[ONCEHUB-100613]: https://scheduleonce.atlassian.net/browse/ONCEHUB-100613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ