### PR TITLE
stable version v5.1.4 for package vite in knowledgeowl-angular

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/knowledgeowl-angular",
-  "version": "5.1.3",
+  "version": "5.1.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/knowledgeowl-angular",
-      "version": "5.1.3",
+      "version": "5.1.4-beta.0",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oncehub/knowledgeowl-angular",
-  "version": "5.1.4-beta.0",
+  "version": "5.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oncehub/knowledgeowl-angular",
-      "version": "5.1.4-beta.0",
+      "version": "5.1.4",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/scheduleonce/knowledgeowl-angular.git"
   },
   "license": "MIT",
-  "version": "5.1.4-beta.0",
+  "version": "5.1.4",
   "scripts": {
     "ng": "ng",
     "build": "ng build --configuration production && cp README.md dist/knowledgeowl-angular",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/scheduleonce/knowledgeowl-angular.git"
   },
   "license": "MIT",
-  "version": "5.1.3",
+  "version": "5.1.4-beta.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build --configuration production && cp README.md dist/knowledgeowl-angular",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oncehub/knowledgeowl-angular",
-    "version": "5.1.3",
+    "version": "5.1.4-beta.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oncehub/knowledgeowl-angular",
-            "version": "5.1.3",
+            "version": "5.1.4-beta.0",
             "license": "MIT"
         }
     }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oncehub/knowledgeowl-angular",
-    "version": "5.1.4-beta.0",
+    "version": "5.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oncehub/knowledgeowl-angular",
-            "version": "5.1.4-beta.0",
+            "version": "5.1.4",
             "license": "MIT"
         }
     }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oncehub/knowledgeowl-angular",
-    "version": "5.1.3",
+    "version": "5.1.4-beta.0",
     "description": "Knowledge Owl Angular",
     "license": "MIT",
     "repository": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oncehub/knowledgeowl-angular",
-    "version": "5.1.4-beta.0",
+    "version": "5.1.4",
     "description": "Knowledge Owl Angular",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
This pull request updates the package version from 5.1.3 to 5.1.4 throughout the project files. No other changes are included.

- Version bump:
  * Updated the `version` field to 5.1.4 in `package.json`, `src/package.json`, and `src/package-lock.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R10) [[2]](diffhunk://#diff-cc5a2f170768969f124108ad3be7fdbcbed774c11774d99a87a3a78fef4ab97bL3-R3) [[3]](diffhunk://#diff-998cefe66c8f4a3c44a608be658fb845884ddbff34d948ca6c751f57186054b7L3-R9)