### PR TITLE
Updated node versions in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: '24.11.0'
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "24.11.0"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the Node.js version used in GitHub Actions workflows to ensure consistency and compatibility across CI and publishing processes.

Node.js version updates:

* Updated the Node.js version in the `ci.yml` workflow from a matrix of `18.x, 20.x` to a single version, `24.11.0`, to standardize the environment.
* Updated the Node.js version in the `npm-publish.yml` workflow from `"24"` to the specific version `"24.11.0"` for more precise version control.